### PR TITLE
Add React router and basic page for champion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@types/react-dom": "^18.2.17",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-router-dom": "^6.21.0",
         "react-scripts": "5.0.1",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
@@ -3681,6 +3682,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.14.0.tgz",
+      "integrity": "sha512-WOHih+ClN7N8oHk9N4JUiMxQJmRVaOxcg8w7F/oHUXzJt920ekASLI/7cYX8XkntDWRhLZtsk6LbGrkgOAvi5A==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -14974,6 +14983,36 @@
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.21.0.tgz",
+      "integrity": "sha512-hGZ0HXbwz3zw52pLZV3j3+ec+m/PQ9cTpBvqjFQmy2XVUWGn5MD+31oXHb6dVTxYzmAeaiUBYjkoNz66n3RGCg==",
+      "dependencies": {
+        "@remix-run/router": "1.14.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.21.0.tgz",
+      "integrity": "sha512-1dUdVj3cwc1npzJaf23gulB562ESNvxf7E4x8upNJycqyUm5BRRZ6dd3LrlzhtLaMrwOCO8R0zoiYxdaJx4LlQ==",
+      "dependencies": {
+        "@remix-run/router": "1.14.0",
+        "react-router": "6.21.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-scripts": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@types/react-dom": "^18.2.17",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-router-dom": "^6.21.0",
     "react-scripts": "5.0.1",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ const routes = [
   // Home page:
   {
     path: "/",
-    element: (
+    element: ( // o componente que será renderizado. Nesse caso seria interessante mover isso para um arquivo dentro de src/pages
       <>
         <div className="head">
           <div className="title">
@@ -28,8 +28,8 @@ const routes = [
   },
   // página do champ:
   {
-    path: "/champions/:championId",
-    element: <ChampionPage />,
+    path: "/champions/:championId", // Ex: /champions/Annie (Annie é o championId). Dentro de componentes, o parâmetro da URL é acessado por useParams().
+    element: <ChampionPage />, // o componente que será renderizado
   },
 ];
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,21 +1,44 @@
-import React from 'react';
-import './App.css';
+import React from "react";
+import { createBrowserRouter, RouterProvider } from "react-router-dom";
+import "./App.css";
 import Champions from "./resources/Champions.jsx";
+import ChampionPage from "./pages/ChampionPage";
+
+// declaração das rotas/páginas:
+// https://reactrouter.com/en/main/start/tutorial
+const routes = [
+  // Home page:
+  {
+    path: "/",
+    element: (
+      <>
+        <div className="head">
+          <div className="title">
+            <h1>LoL Champs</h1>
+          </div>
+          <div>
+            <img src="favicon.png" className="icone" alt="Ícone"></img>
+          </div>
+        </div>
+        <div>
+          <Champions />
+        </div>
+      </>
+    ),
+  },
+  // página do champ:
+  {
+    path: "/champions/:championId",
+    element: <ChampionPage />,
+  },
+];
+
+const router = createBrowserRouter(routes);
 
 function App() {
   return (
     <div>
-      <div className='head'>
-        <div className="title" >
-          <h1>LoL Champs</h1>     
-        </div>
-        <div>
-          <img src='favicon.png' className='icone' alt='Ícone'></img>
-        </div>
-      </div> 
-      <div >
-        <Champions />
-      </div>
+      <RouterProvider router={router} />
     </div>
   );
 }

--- a/src/pages/ChampionPage.tsx
+++ b/src/pages/ChampionPage.tsx
@@ -4,11 +4,14 @@ import { Link, useParams } from "react-router-dom";
 type Props = {};
 
 export default function ChampionPage({}: Props) {
-  const { championId } = useParams<{ championId: string }>();
+  const { championId } = useParams<{ championId: string }>(); // pegando o parâmetro da URL
 
   return (
     <div>
-      <Link className="text-blue-500 hover:text-blue-700" to={`/`}>Go back</Link>
+      {/* Link serve como um elemento para navegar para outras páginas */}
+      <Link className="text-blue-500 hover:text-blue-700" to={`/`}>
+        Go back
+      </Link>
       <h1 className="text-4xl">
         This page will contain details of a champion!
       </h1>

--- a/src/pages/ChampionPage.tsx
+++ b/src/pages/ChampionPage.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { Link, useParams } from "react-router-dom";
+
+type Props = {};
+
+export default function ChampionPage({}: Props) {
+  const { championId } = useParams<{ championId: string }>();
+
+  return (
+    <div>
+      <Link className="text-blue-500 hover:text-blue-700" to={`/`}>Go back</Link>
+      <h1 className="text-4xl">
+        This page will contain details of a champion!
+      </h1>
+      Showing champion: {championId}
+    </div>
+  );
+}


### PR DESCRIPTION
- Install react-router-dom to handle router on the client-side (SPA)
- Update `src/App.tsx` to include router and the new routes (Home page and champion page)
- Add new component `src/pages/ChampionPage.tsx` to represent the champion page. In this component we have a link to the home page as well as a way of getting the championId from the URL.